### PR TITLE
C extension with SWIG (counting bytes, not characters)

### DIFF
--- a/doubles_with_rust.py
+++ b/doubles_with_rust.py
@@ -4,6 +4,10 @@ import random
 import itertools
 import myrustlib  # <-- Importing Rust Implemented Library
 
+import sys
+sys.path.append('./pyext-myclib')
+import myclib  # <-- Importing C Implemented Library
+
 
 def count_doubles(val):
     total = 0
@@ -66,6 +70,10 @@ def test_rust(benchmark):
 
 def test_rust_once(benchmark):
     print(benchmark(myrustlib.count_doubles_once, val))
+
+
+def test_c_bytes_once(benchmark):
+    print(benchmark(myclib.count_byte_doubles, val))
 
 
 # def test_rust_regex(benchmark):

--- a/pyext-myclib/build.sh
+++ b/pyext-myclib/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 setup.py build_ext -i

--- a/pyext-myclib/myclib.c
+++ b/pyext-myclib/myclib.c
@@ -1,0 +1,10 @@
+#include "myclib.h"
+
+uint64_t count_byte_doubles(char * str) {
+  uint64_t count = 0;
+  while (str[0] && str[1]) {
+    if (str[0] == str[1]) count++;
+    str++;
+  }
+  return count;
+}

--- a/pyext-myclib/myclib.h
+++ b/pyext-myclib/myclib.h
@@ -1,0 +1,3 @@
+#include <stdint.h>
+
+uint64_t count_byte_doubles(char * str);

--- a/pyext-myclib/myclib.i
+++ b/pyext-myclib/myclib.i
@@ -1,0 +1,7 @@
+%module myclib
+%{
+#include "myclib.h"
+%}
+
+%include "stdint.i"
+%include "myclib.h"

--- a/pyext-myclib/setup.py
+++ b/pyext-myclib/setup.py
@@ -1,0 +1,8 @@
+from distutils.core import setup, Extension
+
+setup(ext_modules=[
+    Extension('_myclib',
+        sources=['myclib.i', 'myclib.c'],
+        depends=['setup.py', 'mylib.h']
+        )
+])


### PR DESCRIPTION
by @martinxyz

Note: the comparision is not really fair because the C extension is comparing
bytes, while python and rust are comparing utf8 characters.

```bash
------------------------------------------------------------------------------------- benchmark: 7 tests ------------------------------------------------------------------------------------
Name (time in us)                 Min                    Max                   Mean              StdDev                 Median                 IQR            Outliers(*)  Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_c_bytes_once            962.7170 (1.0)       1,820.2346 (1.0)         989.9444 (1.0)       51.8415 (1.0)         982.5421 (1.0)       11.8364 (1.18)           15;43     721           1
test_rust_once             1,079.2040 (1.12)      1,883.8202 (1.03)      1,101.9418 (1.11)      85.7826 (1.65)      1,087.5929 (1.11)       9.9953 (1.0)            18;67     879           1
test_rust                  2,806.8721 (2.92)      6,881.0866 (3.78)      2,964.6178 (2.99)     360.4035 (6.95)      2,872.8019 (2.92)     183.9128 (18.40)          13;13     339           1
test_regex                28,782.4213 (29.90)    32,900.5020 (18.07)    29,226.6153 (29.52)    705.3509 (13.61)    29,092.1649 (29.61)    194.7829 (19.49)            2;3      34           1
test_pure_python_once     41,820.9783 (43.44)    46,459.0848 (25.52)    42,251.5536 (42.68)    948.0384 (18.29)    42,014.0354 (42.76)    299.1488 (29.93)            1;2      23           1
test_pure_python          56,672.6997 (58.87)    58,843.5191 (32.33)    57,210.8221 (57.79)    588.5420 (11.35)    56,984.3869 (58.00)    250.2394 (25.04)            3;4      18           1
test_itertools            61,560.3020 (63.94)    62,581.4409 (34.38)    61,776.0723 (62.40)    285.4289 (5.51)     61,637.5552 (62.73)    315.8825 (31.60)            2;1      17           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```