### PR TITLE
improve C and add numba

### DIFF
--- a/doubles_all.py
+++ b/doubles_all.py
@@ -9,6 +9,18 @@ import sys
 sys.path.append('./pyext-myclib')
 
 import myclib  # <-- Importing C Implemented Library
+from numba import jit
+
+@jit(nopython=True)
+def count_doubles_once_numba(val):
+    total = 0
+    chars = iter(val)
+    c1 = next(chars)
+    for c2 in chars:
+        if c1 == c2:
+            total += 1
+        c1 = c2
+    return total
 
 
 def count_doubles(val):
@@ -65,6 +77,10 @@ def test_pure_python(benchmark):
 
 def test_pure_python_once(benchmark):
     print(benchmark(count_doubles_once, val))
+
+
+def test_pure_python_once_numba(benchmark):
+    print(benchmark(count_doubles_once_numba, val.encode()))
 
 
 def test_itertools(benchmark):

--- a/doubles_all.py
+++ b/doubles_all.py
@@ -11,7 +11,7 @@ sys.path.append('./pyext-myclib')
 import myclib  # <-- Importing C Implemented Library
 from numba import jit
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def count_doubles_once_numba(val):
     total = 0
     chars = iter(val)
@@ -64,6 +64,11 @@ def count_double_numpy(val):
     return np.sum(ng[:-1] == ng[1:])
 
 
+@jit(nopython=True, cache=True)
+def count_double_numpy_numba(ng):
+    return np.sum(ng[:-1] == ng[1:])
+
+
 def count_doubles_comprehension(val):
     return sum(1 for c1, c2 in zip(val, val[1:]) if c1 == c2)
 
@@ -93,6 +98,11 @@ def test_regex(benchmark):
 
 def test_numpy(benchmark):
     print(benchmark(count_double_numpy, val))
+
+
+def test_numpy_numba(benchmark):
+    ng = np.fromstring(val, dtype=np.byte)
+    print(benchmark(count_double_numpy_numba, ng))
 
 
 def test_python_comprehension(benchmark):

--- a/pyext-myclib/myclib.c
+++ b/pyext-myclib/myclib.c
@@ -1,8 +1,10 @@
 #include "myclib.h"
+#include <string.h>
 
 uint64_t count_byte_doubles(char * str) {
   uint64_t count = 0;
-  while (str[0] && str[1]) {
+  int len = strlen(str);
+  while (len--) {
     if (str[0] == str[1]) count++;
     str++;
   }

--- a/pyext-myclib/setup.py
+++ b/pyext-myclib/setup.py
@@ -6,6 +6,7 @@ setup(
         Extension(
             '_myclib',
             sources=['myclib.i', 'myclib.c'],
+            extra_compile_args=["-march=native","-O3"],
             depends=['setup.py', 'mylib.h']
         )
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-benchmark
 numpy
+numba


### PR DESCRIPTION
* Added -O3 and -march=native to C
* Using strlen, somehow, GCC (Debian 6.3.0-18)  decides to vectorize. See also: https://godbolt.org/g/EEwvam
* added numba to requirements
* added a numba jit example over simplest python implementation
* added another example, numpy call on numba jit
* enable jit compilation cache