### PR TITLE
SIMD (arch=native build) for Rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test-all: ## run tests quickly with the default Python
 	py.test -v -s doubles_all.py
 
 compile-rust: ## compile new rust lib
-	@cd pyext-myrustlib;cargo build --release
+	@cd pyext-myrustlib;RUSTFLAGS="-C target-cpu=native" cargo build --release
 	@cp pyext-myrustlib/target/release/libmyrustlib.so myrustlib.so
 
 compile-c: ## compile new c lib


### PR DESCRIPTION
For me, allowing LLVM to target native CPU instructions gives a nearly 2x speedup (and it's a single line change!).
Before:
```
------------------------------------------------------------------------------------------------- benchmark: 10 tests --------------------------------------------------------------------------------------------------                                                        
Name (time in us)                     Min                    Max                   Mean                StdDev                 Median                   IQR            Outliers         OPS            Rounds  Iterations                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------                                                        
test_rust_bytes_once             463.7750 (1.0)       2,320.4550 (1.0)         467.5096 (1.0)         44.6473 (1.0)         465.6775 (1.0)          1.9260 (1.0)        15;122  2,138.9934 (1.0)        1830           1 
```
After:
```
----------------------------------------------------------------------------------------------- benchmark: 10 tests ------------------------------------------------------------------------------------------------                                                            
Name (time in us)                     Min                    Max                   Mean              StdDev                 Median                 IQR            Outliers         OPS            Rounds  Iterations                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------                                                            
test_rust_bytes_once             289.5610 (1.0)       2,190.4260 (1.04)        301.0328 (1.0)       38.1051 (1.0)         299.3540 (1.0)        1.8437 (1.30)       62;823  3,321.8976 (1.0)        2883           1
```