### PR TITLE
Add several alternative rust methods with minor speed optimizations

### DIFF
--- a/doubles_with_rust.py
+++ b/doubles_with_rust.py
@@ -68,5 +68,17 @@ def test_rust_once(benchmark):
     print(benchmark(myrustlib.count_doubles_once, val))
 
 
+def test_rust_peek(benchmark):
+    print(benchmark(myrustlib.count_doubles_peek, val))
+
+
+def test_rust_memreplace(benchmark):
+    print(benchmark(myrustlib.count_doubles_memreplace, val))
+
+
+def test_rust_fold(benchmark):
+    print(benchmark(myrustlib.count_doubles_fold, val))
+
+
 # def test_rust_regex(benchmark):
 #     print(benchmark(myrustlib.count_doubles_regex, val))

--- a/pyext-myrustlib/src/lib.rs
+++ b/pyext-myrustlib/src/lib.rs
@@ -3,6 +3,7 @@
 
 use cpython::{Python, PyResult};
 // use regex::Regex;
+use std::mem;
 
 fn count_doubles(_py: Python, val: &str) -> PyResult<u64> {
     let mut total = 0u64;
@@ -26,6 +27,54 @@ fn count_doubles_once(_py: Python, val: &str) -> PyResult<u64> {
                 total += 1;
             }
             c1 = c2;
+        }
+    }
+
+    Ok(total)
+}
+
+fn count_doubles_memreplace(_py: Python, val: &str) -> PyResult<u64> {
+    let mut total = 0u64;
+
+    let mut chars = val.chars();
+    if let Some(mut c1) = chars.next() {
+        for c2 in chars {
+            if c1 == c2 {
+                total += 1;
+            }
+            mem::replace(&mut c1, c2);
+        }
+    }
+
+    Ok(total)
+}
+
+fn count_doubles_fold(_py: Python, val: &str) -> PyResult<u64> {
+    let mut total = 0u64;
+
+    let mut chars = val.chars();
+    if let Some(c1) = chars.next() {
+        chars.fold(c1, |c1, c2| {
+            if c1 == c2 {
+                total += 1
+            }
+            c2
+        });
+    }
+
+    Ok(total)
+}
+
+fn count_doubles_peek(_py: Python, val: &str) -> PyResult<u64> {
+    let mut total = 0u64;
+
+    let mut chars = val.chars().peekable();
+
+    while let Some(c1) = chars.next() {
+        if let Some(c2) = chars.peek() {
+            if &c1 == c2 {
+                total += 1;
+            }
         }
     }
 
@@ -63,6 +112,9 @@ py_module_initializer!(libmyrustlib, initlibmyrustlib, PyInit_myrustlib, |py, m 
     try!(m.add(py, "count_doubles", py_fn!(py, count_doubles(val: &str))));
     try!(m.add(py, "count_doubles_once", py_fn!(py, count_doubles_once(val: &str))));
     try!(m.add(py, "count_doubles_once_bytes", py_fn!(py, count_doubles_once_bytes(val: &str))));
+    try!(m.add(py, "count_doubles_peek", py_fn!(py, count_doubles_peek(val: &str))));
+    try!(m.add(py, "count_doubles_memreplace", py_fn!(py, count_doubles_memreplace(val: &str))));
+    try!(m.add(py, "count_doubles_fold", py_fn!(py, count_doubles_fold(val: &str))));
     // try!(m.add(py, "count_doubles_regex", py_fn!(py, count_doubles_regex(val: &str))));
     Ok(())
 });


### PR DESCRIPTION
This pull request adds several alternative Rust implementations of `count_doubles` that are more like minmaxing attempts than actual optimizations.

`count_doubles_memreplace` changes assignment in original  `count_doubles_once` to `mem::replace` call.
`count_doubles_fold` gets rid of for loop in favor of `fold` iteration
`count_doubles_peek` uses peeking iterator which is supposed to also iterate once.

For first two methods, performance gains are pretty minor, and the last one, while being faster than the original `count_doubles` method, is actually about two times slower than existing `count_doubles_once`. But I think it will be good to keep them as reference.

Benchmark results on my PC (Ubuntu 17.10, Linux core 4.13.0-17, Intel(R) Core(TM) i3-7100U CPU @ 2.40GHz):

```
$ python3 -m pytest doubles_with_rust.py 
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.6.3, pytest-3.2.5, py-1.5.2, pluggy-0.4.0
benchmark: 3.1.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)

plugins: benchmark-3.1.1

...
 
----------------------------------------------------------------------------------- benchmark: 9 tests -----------------------------------------------------------------------------------
Name (time in ms)             Min                Max               Mean            StdDev             Median               IQR            Outliers       OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rust_memreplace       1.3039 (1.0)       2.1781 (1.39)      1.3160 (1.00)     0.0703 (3.18)      1.3046 (1.00)     0.0027 (1.08)        19;96  759.8687 (1.00)        744           1
test_rust_fold             1.3039 (1.00)      1.5680 (1.0)       1.3099 (1.0)      0.0221 (1.0)       1.3045 (1.00)     0.0025 (1.0)         38;69  763.3948 (1.0)         750           1
test_rust_once             1.3039 (1.00)      2.4590 (1.57)      1.3107 (1.00)     0.0490 (2.22)      1.3044 (1.0)      0.0025 (1.00)        14;66  762.9646 (1.00)        749           1
test_rust_peek             2.5571 (1.96)      3.7083 (2.36)      2.5795 (1.97)     0.0892 (4.04)      2.5598 (1.96)     0.0056 (2.27)        14;65  387.6769 (0.51)        385           1
test_rust                  3.3923 (2.60)      4.2454 (2.71)      3.4136 (2.61)     0.0709 (3.21)      3.3953 (2.60)     0.0073 (2.93)        15;49  292.9455 (0.38)        291           1
test_regex                28.6579 (21.98)    33.2731 (21.22)    29.2737 (22.35)    1.1329 (51.32)    28.8465 (22.11)    0.2842 (113.98)        4;5   34.1604 (0.04)         34           1
test_pure_python_once     42.5546 (32.64)    42.9971 (27.42)    42.6845 (32.59)    0.1105 (5.00)     42.6513 (32.70)    0.1091 (43.74)         6;2   23.4277 (0.03)         24           1
test_pure_python          57.2202 (43.88)    63.5213 (40.51)    58.2453 (44.46)    1.8799 (85.16)    57.3243 (43.95)    0.3793 (152.14)        4;4   17.1688 (0.02)         19           1
test_itertools            67.2091 (51.54)    68.1911 (43.49)    67.3729 (51.43)    0.2317 (10.49)    67.3168 (51.61)    0.0883 (35.41)         1;2   14.8428 (0.02)         16           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
```