### PR TITLE
count repeated bytes with overlapping slices

### DIFF
--- a/doubles_with_rust.py
+++ b/doubles_with_rust.py
@@ -79,6 +79,8 @@ def test_rust_memreplace(benchmark):
 def test_rust_fold(benchmark):
     print(benchmark(myrustlib.count_doubles_fold, val))
 
+def test_rust_slice(benchmark):
+    print(benchmark(myrustlib.count_doubles_slice, val))
 
 # def test_rust_regex(benchmark):
 #     print(benchmark(myrustlib.count_doubles_regex, val))

--- a/pyext-myrustlib/src/lib.rs
+++ b/pyext-myrustlib/src/lib.rs
@@ -95,6 +95,11 @@ fn count_doubles_once_bytes(_py: Python, val: &str) -> PyResult<u64> {
     Ok(total)
 }
 
+fn count_doubles_slice(_py: Python, val: &str) -> PyResult<u64> {
+    let count = val.as_bytes().windows(2).filter(|slice| slice[0] == slice[1]).count();
+    Ok(count as u64)
+}
+
 
 // Rust Gegex crate does not support lokkaround/backreference
 // https://github.com/rust-lang/regex/issues/302
@@ -113,6 +118,7 @@ py_module_initializer!(libmyrustlib, initlibmyrustlib, PyInit_myrustlib, |py, m 
     try!(m.add(py, "count_doubles_peek", py_fn!(py, count_doubles_peek(val: &str))));
     try!(m.add(py, "count_doubles_memreplace", py_fn!(py, count_doubles_memreplace(val: &str))));
     try!(m.add(py, "count_doubles_fold", py_fn!(py, count_doubles_fold(val: &str))));
+    try!(m.add(py, "count_doubles_slice", py_fn!(py, count_doubles_slice(val: &str))));
     // try!(m.add(py, "count_doubles_regex", py_fn!(py, count_doubles_regex(val: &str))));
     Ok(())
 });


### PR DESCRIPTION
from running `doubles_with_rust.py`
```
--------------------------------------------------------------------------------------------- benchmark: 10 tests ----------------------------------------------------------------------------------------------
Name (time in us)                 Min                    Max                   Mean              StdDev                 Median                 IQR            Outliers         OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rust_slice              439.6520 (1.0)         568.0390 (1.0)         443.2207 (1.0)       11.6911 (1.0)         439.9550 (1.0)        0.2310 (1.0)       152;469  2,256.2121 (1.0)        2250           1
test_rust_memreplace         819.5370 (1.86)        996.3340 (1.75)        824.1257 (1.86)      14.1387 (1.21)        819.9170 (1.86)       2.6083 (11.29)     101;110  1,213.4072 (0.54)       1205           1
test_rust_fold               819.5420 (1.86)      1,021.4020 (1.80)        824.5106 (1.86)      14.5709 (1.25)        819.8955 (1.86)       2.6110 (11.30)     103;123  1,212.8407 (0.54)       1214           1
test_rust_once               819.5530 (1.86)      1,040.5240 (1.83)        825.1302 (1.86)      17.3818 (1.49)        819.9070 (1.86)       2.7060 (11.71)      94;117  1,211.9300 (0.54)       1176           1
test_rust_peek             1,358.7930 (3.09)      1,528.5940 (2.69)      1,366.3480 (3.08)      19.1660 (1.64)      1,359.2830 (3.09)       3.4000 (14.72)      75;107    731.8780 (0.32)        734           1
test_rust                  1,505.8550 (3.43)      1,678.1010 (2.95)      1,513.4368 (3.41)      19.2407 (1.65)      1,508.2350 (3.43)       3.0570 (13.23)       67;84    660.7478 (0.29)        653           1
test_regex                24,470.5680 (55.66)    25,124.0330 (44.23)    24,612.1417 (55.53)    124.0519 (10.61)    24,564.2580 (55.83)    133.6237 (578.47)        9;1     40.6304 (0.02)         41           1
test_pure_python_once     31,629.5480 (71.94)    32,306.6860 (56.87)    31,800.9409 (71.75)    186.9089 (15.99)    31,743.6310 (72.15)    134.7310 (583.26)        5;4     31.4456 (0.01)         31           1
test_pure_python          42,957.9590 (97.71)    43,536.1770 (76.64)    43,178.8139 (97.42)    143.2057 (12.25)    43,185.5720 (98.16)    174.5725 (755.73)        8;1     23.1595 (0.01)         23           1
test_itertools            48,368.4220 (110.02)   49,300.9220 (86.79)    48,799.1648 (110.10)   282.2380 (24.14)    48,844.6920 (111.02)   445.8117 (>1000.0)       8;0     20.4922 (0.01)         21           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```