### PR TITLE
[PR] copy dll / so via build.rs instead of using makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ test-all: ## run tests quickly with the default Python
 
 compile-rust: ## compile new rust lib
 	@cd pyext-myrustlib;RUSTFLAGS="-C target-cpu=native" cargo build --release
-	@cp pyext-myrustlib/target/release/libmyrustlib.so myrustlib.so
 
 compile-c: ## compile new c lib
 	@cd pyext-myclib;python3 setup.py build_ext -i

--- a/pyext-myrustlib/build.rs
+++ b/pyext-myrustlib/build.rs
@@ -1,0 +1,10 @@
+// build.rs
+use std::fs;
+
+fn main() { 
+    let source_ext = if cfg!(windows) { "dll" } else { "so" };
+    let target_ext = if cfg!(windows) { "pyd" } else { "so" };
+    let _ = fs::copy(format!("target/release/myrustlib.{ext}", ext= source_ext), 
+                     format!("../myrustlib.{}", target_ext));
+    println!("created python lib");
+}

--- a/pyext-myrustlib/src/lib.rs
+++ b/pyext-myrustlib/src/lib.rs
@@ -40,7 +40,7 @@ fn count_doubles_memreplace(_py: Python, val: &str) -> PyResult<u64> {
             if c1 == c2 {
                 total += 1;
             }
-            mem::replace(&mut c1, c2);
+            let _ = mem::replace(&mut c1, c2);
         }
     }
 


### PR DESCRIPTION
https://github.com/rochacbruno/rust-python-example/issues/22
Avoid to manually copy and rename dll on windows